### PR TITLE
Improve list rendering and voice call controls

### DIFF
--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -152,6 +152,11 @@
       inputInner.appendChild(sttOverlay);
     }
 
+    if (input && callBtn) {
+      input.addEventListener('focus', () => { callBtn.style.display = 'none'; });
+      input.addEventListener('blur', () => { callBtn.style.display = ''; });
+    }
+
     if (voiceBtn && navigator.mediaDevices) {
       let mediaRecorder = null;
       let chunks = [];
@@ -981,21 +986,27 @@ function extractSuggestions(raw, replyOrRaw) {
       // 5) Escapa HTML básico
       out = escapeHtml(out);
 
-      // 6) Markdown sencillo -> HTML
+      // 6) Permite algunas etiquetas ya formateadas (<ul>, <ol>, <li>, <br>, <strong>)
+      out = out.replace(/&lt;(\/?(?:ul|ol|li|br|strong))&gt;/gi, '<$1>');
+
+      // 7) Markdown sencillo -> HTML
       // Negritas **texto**
       out = out.replace(/\*\*(.+?)\*\*/g, '<strong>$1<\/strong>');
 
       // Listas con guiones o asteriscos o viñetas
-      out = out.replace(/(^|\n)(?:[-*•]\s.+)(?:\n[-*•]\s.+)*/g, (m) => {
-        const items = m.trim().split(/\n/).map(line => line.replace(/^[-*•]\s+/, ''));
+      out = out.replace(/(^|\n)\s*(?:[-*•]\s.+)(?:\n\s*[-*•]\s.+)*/g, (m) => {
+        const items = m.trim().split(/\n/).map(line => line.replace(/^\s*[-*•]\s+/, ''));
         return '<ul><li>' + items.join('</li><li>') + '</li></ul>';
       });
 
       // Listas numeradas
-      out = out.replace(/(^|\n)(?:\d+\.\s.+)(?:\n\d+\.\s.+)*/g, (m) => {
-        const items = m.trim().split(/\n/).map(line => line.replace(/^\d+\.\s+/, ''));
+      out = out.replace(/(^|\n)\s*(?:\d+\.\s.+)(?:\n\s*\d+\.\s.+)*/g, (m) => {
+        const items = m.trim().split(/\n/).map(line => line.replace(/^\s*\d+\.\s+/, ''));
         return '<ol><li>' + items.join('</li><li>') + '</li></ol>';
       });
+
+      // 8) Saltos de línea restantes
+      out = out.replace(/\n/g, '<br>');
 
       return out;
     }

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -184,12 +184,13 @@ add_shortcode('am_chat', function(){
       function setState(s){ /* no visible state */ }
       function sanitizeReply(text) {
         let out = String(text || '').replace(/[&<>]/g, (c) => ({ '&':'&amp;','<':'&lt;','>':'&gt;' }[c]));
-        out = out.replace(/(^|\n)(?:[-*•]\s.+)(?:\n[-*•]\s.+)*/g, (m) => {
-          const items = m.trim().split(/\n/).map(line => line.replace(/^[-*•]\s+/, ''));
+        out = out.replace(/&lt;(\/?(?:ul|ol|li|br|strong))&gt;/gi, '<$1>');
+        out = out.replace(/(^|\n)\s*(?:[-*•]\s.+)(?:\n\s*[-*•]\s.+)*/g, (m) => {
+          const items = m.trim().split(/\n/).map(line => line.replace(/^\s*[-*•]\s+/, ''));
           return '<ul><li>' + items.join('</li><li>') + '</li></ul>';
         });
-        out = out.replace(/(^|\n)(?:\d+\.\s.+)(?:\n\d+\.\s.+)*/g, (m) => {
-          const items = m.trim().split(/\n/).map(line => line.replace(/^\d+\.\s+/, ''));
+        out = out.replace(/(^|\n)\s*(?:\d+\.\s.+)(?:\n\s*\d+\.\s.+)*/g, (m) => {
+          const items = m.trim().split(/\n/).map(line => line.replace(/^\s*\d+\.\s+/, ''));
           return '<ol><li>' + items.join('</li><li>') + '</li></ol>';
         });
         out = out.replace(/\n/g, '<br>');
@@ -378,9 +379,10 @@ add_shortcode('am_chat', function(){
         if (micVizInterval){ clearInterval(micVizInterval); micVizInterval=null; }
         if (avatarImg) avatarImg.style.transform='scale(1)';
         if (micStream){ micStream.getTracks().forEach(t=>t.stop()); micStream=null; }
+        if (mediaRecorder && mediaRecorder.stream){ mediaRecorder.stream.getTracks().forEach(t=> t.stop()); }
+        mediaRecorder = null;
         if (micCtx){ try{ micCtx.close(); } catch(_){} micCtx=null; micAnalyser=null; }
         if (currentAudio) { currentAudio.pause(); currentAudio.currentTime = 0; currentAudio = null; }
-        if (mediaRecorder && mediaRecorder.stream){ mediaRecorder.stream.getTracks().forEach(t=> t.enabled = true); }
         micMuted = false;
         if (muteBtn){
           muteBtn.classList.remove('muted');


### PR DESCRIPTION
## Summary
- Ensure AI responses render bullet and numbered lists as proper HTML
- Stop microphone recording when ending voice calls and restore mic state
- Hide voice call button when typing to avoid overlay clashes

## Testing
- `php -l includes/shortcodes.php`
- `node --check assets/js/chat.js`


------
https://chatgpt.com/codex/tasks/task_b_68b2245be3148324bdf3ea1d25cc8935